### PR TITLE
Add ability to pass openssh options via REX_OPENSSH_OPTS

### DIFF
--- a/lib/Rex/Config.pm
+++ b/lib/Rex/Config.pm
@@ -295,6 +295,14 @@ sub get_openssh_opt {
   return %openssh_opt;
 }
 
+sub get_rex_openssh_opt {
+  if ( exists $ENV{REX_OPENSSH_OPTS} ) {
+    my @opts = split / /, $ENV{REX_OPENSSH_OPTS};
+    return @opts;
+  }
+  return 0;
+}
+
 sub set_sudo_without_locales {
   my $class = shift;
   $sudo_without_locales = shift;

--- a/lib/Rex/Interface/Connection/OpenSSH.pm
+++ b/lib/Rex/Interface/Connection/OpenSSH.pm
@@ -92,6 +92,12 @@ sub connect {
     push @ssh_opts_line, "-o" => $key . "=" . $ssh_opts{$key};
   }
 
+  my @rex_openssh_opts = Rex::Config->get_rex_openssh_opt();
+
+  if ( $rex_openssh_opts[0] != 0 ) {
+    push @ssh_opts_line, @rex_openssh_opts;
+  }
+
   my @connection_props = ( "" . $server ); # stringify server object, so that a dumper don't print out passwords.
   push @connection_props, ( user => $user, port => $port );
   push @connection_props, master_opts      => \@ssh_opts_line if @ssh_opts_line;


### PR DESCRIPTION
Minor change that adds the option to pass options to openssh via the REX_OPENSSH_OPTS variable. 

No checks are done on what's passed in, it expects valid options - I don't think it's reasonably possible to actually validate what goes in.

Fixes #2.