### PR TITLE
Finalise name change to trex

### DIFF
--- a/lib/Rex.pm
+++ b/lib/Rex.pm
@@ -74,6 +74,11 @@ package Rex;
 use strict;
 use warnings;
 
+# NAME
+
+$Rex::DISPLAYNAME = "T(R)?ex";
+$Rex::NAME = "TRex";
+
 # VERSION
 
 # development version if this variable is not set
@@ -675,11 +680,11 @@ sub import {
           $Rex::VERSION =~ m/^(\d+)\.(\d+)\.(\d+)[\._]?(\d+)?$/;
 
         my ( $c_major, $c_minor ) = split( /\./, $vers );
-        $dev_release = "sex";
+        $dev_release = "trex";
 
         if ( defined $dev_release ) { # && $c_major == $major && $c_minor > $minor ) {
           Rex::Logger::info(
-            "This is development release $Rex::VERSION of (S)!ex. Feature checks are disabled for $vers until done right.",
+            "This is a development release $Rex::VERSION of $Rex::DISPLAYNAME. Feature checks are disabled for $vers until done right.",
             "warn"
           );
         }

--- a/lib/Rex/CLI.pm
+++ b/lib/Rex/CLI.pm
@@ -95,7 +95,7 @@ sub __run__ {
     Rex::Config->set_use_cache(0);
   }
 
-  Rex::Logger::debug("This is Sex version: $Rex::VERSION");
+  Rex::Logger::debug("This is $Rex::NAME version: $Rex::VERSION");
   Rex::Logger::debug("Command Line Parameters");
   for my $param ( keys %opts ) {
     Rex::Logger::debug( "\t$param = " . $opts{$param} );
@@ -404,8 +404,8 @@ sub __help__ {
   my $fmt = "  %-6s %s\n";
 
   print "usage: \n";
-  print "  rex [<options>] [-H <host>] [-G <group>] <task> [<task-options>]\n";
-  print "  rex -T[m|y|v] [<string>]\n";
+  print "  " . basename($0) . " [<options>] [-H <host>] [-G <group>] <task> [<task-options>]\n";
+  print "  " . basename($0) . " -T[m|y|v] [<string>]\n";
   print "\n";
   printf $fmt, "-b",    "Run batch";
   printf $fmt, "-e",    "Run the given code fragment";
@@ -442,7 +442,7 @@ sub __help__ {
   printf $fmt, "-s", "Use sudo for every command";
   printf $fmt, "-S", "Password for sudo";
   printf $fmt, "-t", "Number of threads to use (aka 'parallelism' param)";
-  printf $fmt, "-v", "Display (S)!ex version";
+  printf $fmt, "-v", "Display $Rex::DISPLAYNAME version";
   print "\n";
 
   for my $code (@help) {
@@ -464,7 +464,7 @@ sub add_exit {
 }
 
 sub __version__ {
-  print "(S)!ex " . $Rex::VERSION . "\n";
+  print $Rex::DISPLAYNAME . " " . $Rex::VERSION . "\n";
   CORE::exit 0;
 }
 


### PR DESCRIPTION
This removes any remainders of the other name and moves name changes to a single location.

Also fixes the help message to show the name of the binary instead of always keeping it rex.